### PR TITLE
Added support for circle and triangle rendering

### DIFF
--- a/src/core/shader_system.cpp
+++ b/src/core/shader_system.cpp
@@ -22,8 +22,11 @@ ShaderProgramPtr ShaderSystem::GetShader(std::string_view id)
 {
     auto shaderIterator = m_storedShaders.find(id.data());
     if (shaderIterator == m_storedShaders.end())
-        throw FormattedException("No shader exists with the ID \"%s\".", id.data());
-
+    {
+        LoggingSystem::GetInstance().Output("No shader exists with the ID \"%s\".", LoggingSystem::Severity::WARNING, id.data());
+        return nullptr;
+    }
+    
     return shaderIterator->second;
 }
 

--- a/src/core/shader_system.h
+++ b/src/core/shader_system.h
@@ -23,6 +23,7 @@ public:
 	void Remove(std::string_view id);
 
 	// Returns reference to the stored shader that is attached to the specified ID.
+	// If no shader is found with the specified ID, then nullptr will be returned.
 	ShaderProgramPtr GetShader(std::string_view id);
 
 	// Returns singleton instance of the class.

--- a/src/core/texture_system.cpp
+++ b/src/core/texture_system.cpp
@@ -56,7 +56,10 @@ Texture2DPtr TextureSystem::GetTexture(std::string_view id)
 {
     auto textureIterator = m_storedTextures.find(id.data());
     if (textureIterator == m_storedTextures.end())
-        throw FormattedException("No texture image exists with the ID \"%s\".", id.data());
+    {
+        LoggingSystem::GetInstance().Output("No texture image exists with the ID \"%s\".", LoggingSystem::Severity::WARNING, id.data());
+        return nullptr;
+    }
 
     return textureIterator->second;
 }

--- a/src/core/texture_system.h
+++ b/src/core/texture_system.h
@@ -25,6 +25,7 @@ public:
 	void Remove(std::string_view id);
 
 	// Returns reference to the stored texture that is attached to the specified ID.
+	// If no texture is found with the specified ID, then nullptr will be returned.
 	Texture2DPtr GetTexture(std::string_view id);
 
 	// Returns singleton instance of the class.

--- a/src/graphics/geometry.h
+++ b/src/graphics/geometry.h
@@ -14,6 +14,17 @@ public:
 		RENDER_ELEMENTS
 	};
 
+	enum class PrimitiveType : uint32_t
+	{
+		POINTS = 0x0000,
+		LINES = 0x0001,
+		LINE_LOOP = 0x0002,
+		LINE_STRIP = 0x0003,
+		TRIANGLES = 0x0004,
+		TRIANGLE_STRIP = 0x0005,
+		TRIANGLE_FAN = 0x0006
+	};
+	
 	struct Transform
 	{
 		glm::vec3 m_position = glm::vec3(0.0f), m_size = glm::vec3(1.0f), m_rotationAxis = glm::vec3(1.0f);
@@ -35,6 +46,7 @@ protected:
 
 	// Rendering parameters
 	RenderFunction m_renderFunc;
+	PrimitiveType m_primitiveType;
 	uint32_t m_count;
 
 	// Buffer objects
@@ -86,8 +98,11 @@ public:
 	// Returns the geometry's material data.
 	const Material& GetMaterialData() const;
 
-	// Returns enum specifying the function to use to render the geometry.
-	const RenderFunction& GetRenderFunction() const;
+	// Returns an enum specifying the function to use to render the geometry.
+	RenderFunction GetRenderFunction() const;
+
+	// Returns an enum specifying the primitive type to use when rendering the geometry.
+	PrimitiveType GetPrimitiveType() const;
 
 	// Returns the number of vertices/indices in the geometry.
 	// For geometry using RenderFunction::RENDER_ARRAYS, the number of vertices should be returned. 
@@ -104,6 +119,28 @@ public:
 	Square(const Transform& transform, const Material& material);
 
 	virtual ~Square() = default;
+};
+
+class Triangle : public Geometry
+{
+protected:
+	virtual void InitGeometryData() override;
+public:
+	Triangle();
+	Triangle(const Transform& transform, const Material& material);
+
+	virtual ~Triangle() = default;
+};
+
+class Circle : public Geometry
+{
+protected:
+	virtual void InitGeometryData() override;
+public:
+	Circle();
+	Circle(const Transform& transform, const Material& material);
+
+	virtual ~Circle() = default;
 };
 
 #endif

--- a/src/graphics/renderer.cpp
+++ b/src/graphics/renderer.cpp
@@ -50,9 +50,9 @@ void Renderer::Render(const Camera3D& camera, const Geometry& geometry) const
 
     // Draw the geometry
     if (geometry.GetRenderFunction() == Geometry::RenderFunction::RENDER_ARRAYS)
-        glDrawArrays(GL_TRIANGLES, 0, geometry.GetCount());
+        glDrawArrays((uint32_t)geometry.GetPrimitiveType(), 0, geometry.GetCount());
     else if (geometry.GetRenderFunction() == Geometry::RenderFunction::RENDER_ELEMENTS)
-        glDrawElements(GL_TRIANGLES, geometry.GetCount(), GL_UNSIGNED_INT, nullptr);
+        glDrawElements((uint32_t)geometry.GetPrimitiveType(), geometry.GetCount(), GL_UNSIGNED_INT, nullptr);
 }
 
 Renderer& Renderer::GetInstance()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,7 @@ int main()
 			while (accumulatedRenderTime >= timeStep)
 			{
 				///////////////////////////////// CAMERA CONTROLS (TEMPORARY) /////////////////////////////////
+
 				const glm::vec3 cameraDirection = camera.GetDirection();
 				const glm::vec3 cameraPerpDirection = glm::cross(camera.GetDirection(), { 0.0f, 1.0f, 0.0f });
 				const float cameraSpeed = 5.0f;
@@ -107,6 +108,14 @@ int main()
 			material.m_enableTextures = true;
 
 			Renderer::GetInstance().Render(camera, Square(transform, material));
+
+			transform.m_position = { 5.0f, 0.0f, -5.0f, };
+
+			Renderer::GetInstance().Render(camera, Triangle(transform, material));
+
+			transform.m_position = { 2.5f, 0.0f, -5.0f, };
+
+			Renderer::GetInstance().Render(camera, Circle(transform, material));
 
 			/////////////////////////
 


### PR DESCRIPTION
Changes made include:

- Added `Triangle` and `Circle` classes which inherit from the `Geometry` class, these are used for rendering circle/triangle shapes.
- The functions `GetTexture()` and `GetShader()` now don't throw an exception if no texture/shader was found with the ID specified, instead they now just output a `WARNING` log and return `nullptr`.